### PR TITLE
WyzeAccessory.js  - improve device compatibility

### DIFF
--- a/src/accessories/WyzeAccessory.js
+++ b/src/accessories/WyzeAccessory.js
@@ -88,27 +88,7 @@ module.exports = class WyzeAccessory {
     const productModel = device.product_model
 
     switch (productType) {
-      case "OutdoorPlug":
-        if(productModel == "WLPPO-SUB") {
-          this.homeKitAccessory.context = {
-            mac: device.mac,
-            product_type: device.product_type,
-            product_model: device.product_model,
-            nickname: device.nickname,
-            conn_state: device.conn_state,
-            push_switch: device.push_switch,
-            device_params: device.device_params = {
-              switch_state: device.device_params.switch_state,
-              photosensitive_switch: device.device_params.photosensitive_switch,
-              ssid : device.device_params.ssid,
-              ip : device.device_params.ip,
-              rssi : device.device_params.rssi,
-            }, 
-          }
-          break
-        }
       case "Plug":
-        if(productModel == "WLPP1") {
         this.homeKitAccessory.context = {
           mac: device.mac,
           product_type: device.product_type,
@@ -124,7 +104,6 @@ module.exports = class WyzeAccessory {
             },
         }
         break
-      }
       case "Common":
         if(productModel == "LD_SS1") {
         this.homeKitAccessory.context = {
@@ -146,7 +125,6 @@ module.exports = class WyzeAccessory {
         break
       }
       case "Camera":
-        if(productModel == "WYZEC1-JZ" || productModel == "WYZEDB3" || productModel == "WYZE_CAKP2JFUS") {
         this.homeKitAccessory.context = {
           mac: device.mac,
           product_type: device.product_type,
@@ -165,7 +143,6 @@ module.exports = class WyzeAccessory {
           },
         }
         break
-      }
       case "LightStrip":
       case "Light":
       case "MeshLight":


### PR DESCRIPTION
Improving compatibility with Wyze devices by removing some productModel checks. 
Plug may have new productModel strings but they are compatible with WLPP1 so check removed. 
OutdoorPlug case is duplicated, one with model check and one without, so deleted case with check. 
Removed model check from Camera case to enable Pan and Pro models, Outdoor v1/v2, etc... 
   Accessory toggles privacy mode vs. power on some cameras (Pan v3 for example) but should be functional.